### PR TITLE
feat: cascade delete transactions when deleting a wallet

### DIFF
--- a/app/(tabs)/wallet/index.tsx
+++ b/app/(tabs)/wallet/index.tsx
@@ -106,7 +106,11 @@ const WalletScreen = () => {
               const batch = writeBatch(db);
 
               // 1. Query all transactions associated with this wallet
-              const transactionsQuery = query(collection(db, 'transactions'), where('walletId', '==', walletId));
+              const transactionsQuery = query(
+                collection(db, 'transactions'), 
+                where('walletId', '==', walletId),
+                where('userId', '==', userId)
+              );
               const transactionsSnapshot = await getDocs(transactionsQuery);
 
               // 2. Add each transaction deletion to the batch


### PR DESCRIPTION
### Summary
This PR implements **Cascade Deletion** for wallets to ensure database integrity. When a user deletes a wallet, all transactions associated with that specific wallet are now automatically and atomically removed from Firestore using a batched write operation.

### Changes
- **Atomic Deletion**: Implemented `writeBatch` in `handleDeleteWallet` to ensure that either both the wallet and its transactions are deleted, or neither is (preventing orphaned transactions).
- **Security Compliance**: Scoped the transaction lookup query to the current `userId`. This satisfies the updated Firestore Security Rules that restrict document access to the owner, resolving the "Missing or insufficient permissions" error during deletion.
- **UX Update**: Updated the deletion confirmation alert to inform the user that all related transactions will also be permanently removed.

### Verification
- [x] Verified that deleting a wallet pulls the correct transactions via `walletId` + `userId` filter.
- [x] Confirmed Firestore Batch `commit()` executes successfully with updated security rules.
- [x] Tested "Cancel" action to ensure no deletions occur if the user changes their mind.

Closes #6