### PR TITLE
feat: colorized type toggle and fixed form reset bug

### DIFF
--- a/app/(tabs)/transactions/new.tsx
+++ b/app/(tabs)/transactions/new.tsx
@@ -30,8 +30,10 @@ const AddTransactionScreen = () => {
             setAmount('');
             setNote('');
             setSelectedWallet(null);
-            setSelectedCategory(type === 'expense' ? EXPENSE_CATEGORIES[0].id : INCOME_CATEGORIES[0].id);
-        }, [type])
+            setImageNoteBase64(null);
+            setType('expense');
+            setSelectedCategory(EXPENSE_CATEGORIES[0].id);
+        }, []) // Empty dependencies ensure this only runs once per focus, not on type toggle
     );
 
     // Auto-switch category selection when toggling between expense and income


### PR DESCRIPTION
This PR colorizes the Income/Expense toggle for better visual clarity and fixes a bug where detail inputs were being reset when toggling between types.

Key Changes:
-   🎨 New colored selection: Red for Expense, Green for Income.
-   🛠️ Fixed bug where `useFocusEffect` was clearing the form whenever `type` changed.
-   🧹 Added reset for `imageNoteBase64` when starting a new transaction.