### PR TITLE
fix: consistent green in income breakdown summary

### DIFF
--- a/app/(tabs)/summary/index.tsx
+++ b/app/(tabs)/summary/index.tsx
@@ -335,13 +335,13 @@ const SummaryScreen = () => {
                                 ) : (
                                     incomeBreakdown.map((cat) => (
                                         <View key={cat.name} style={styles.breakdownRow}>
-                                            <View style={[styles.categoryIconBg, { backgroundColor: cat.color + '20' }]}>
-                                                <Ionicons name={cat.icon as any} size={16} color={cat.color} />
+                                            <View style={[styles.categoryIconBg, { backgroundColor: INCOME_COLOR + '20' }]}>
+                                                <Ionicons name={cat.icon as any} size={16} color={INCOME_COLOR} />
                                             </View>
                                             <View style={{ flex: 1 }}>
                                                 <Text style={styles.breakdownName}>{cat.name}</Text>
                                                 <View style={styles.breakdownTrack}>
-                                                    <View style={[styles.breakdownFill, { width: `${cat.percentage}%`, backgroundColor: cat.color }]} />
+                                                    <View style={[styles.breakdownFill, { width: `${cat.percentage}%`, backgroundColor: INCOME_COLOR }]} />
                                                 </View>
                                             </View>
                                             <Text style={[styles.breakdownAmount, { color: INCOME_COLOR }]}>฿{cat.total.toLocaleString()}</Text>


### PR DESCRIPTION
This PR fixes the color inconsistency in the Income Breakdown section on the Summary page.

Changes:
-   🎨 Replaced category-specific colors in the income breakdown with the shared brand `INCOME_COLOR` for icons and progress bars.
-   🛡️ Ensures the entire Income section maintains a consistent, unified green theme.
-   🧹 All incidental UI overhauls were reverted as per the user request.