### PR TITLE
fix: firestore rule robustness and null safety v2

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,5 @@
+{
+  "firestore": {
+    "rules": "firestore.rules"
+  }
+}

--- a/firestore.rules
+++ b/firestore.rules
@@ -4,12 +4,16 @@ service cloud.firestore {
     
     // Helper function to check if user is owner of the wallet
     function isWalletOwner(walletId) {
-      return get(/databases/$(database)/documents/wallets/$(walletId)).data.userId == request.auth.uid;
+      let walletPath = /databases/$(database)/documents/wallets/$(walletId);
+      return exists(walletPath) && get(walletPath).data.userId == request.auth.uid;
     }
     
     // Helper function to check if user is member of the wallet
     function isWalletMember(walletId) {
-      return request.auth.uid in get(/databases/$(database)/documents/wallets/$(walletId)).data.sharedWith;
+      let walletPath = /databases/$(database)/documents/wallets/$(walletId);
+      return exists(walletPath) && 
+             "sharedWith" in get(walletPath).data && 
+             request.auth.uid in get(walletPath).data.sharedWith;
     }
 
     // 1. Users can read and write their own profile
@@ -31,16 +35,20 @@ service cloud.firestore {
     match /transactions/{transactionId} {
       allow read: if request.auth != null && (
         resource.data.userId == request.auth.uid || 
-        isWalletOwner(resource.data.walletId) || 
-        isWalletMember(resource.data.walletId)
+        (
+          "walletId" in resource.data && 
+          (isWalletOwner(resource.data.walletId) || isWalletMember(resource.data.walletId))
+        )
       );
+      
       allow create: if request.auth != null && 
         request.resource.data.userId == request.auth.uid && 
+        "walletId" in request.resource.data && 
         (isWalletOwner(request.resource.data.walletId) || isWalletMember(request.resource.data.walletId));
         
       allow update, delete: if request.auth != null && (
         resource.data.userId == request.auth.uid || 
-        isWalletOwner(resource.data.walletId)
+        ("walletId" in resource.data && isWalletOwner(resource.data.walletId))
       );
     }
   }

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,0 +1,47 @@
+rules_version = '2';
+service cloud.firestore {
+  match /databases/{database}/documents {
+    
+    // Helper function to check if user is owner of the wallet
+    function isWalletOwner(walletId) {
+      return get(/databases/$(database)/documents/wallets/$(walletId)).data.userId == request.auth.uid;
+    }
+    
+    // Helper function to check if user is member of the wallet
+    function isWalletMember(walletId) {
+      return request.auth.uid in get(/databases/$(database)/documents/wallets/$(walletId)).data.sharedWith;
+    }
+
+    // 1. Users can read and write their own profile
+    match /users/{userId} {
+      allow read, write: if request.auth != null && request.auth.uid == userId;
+    }
+    
+    // 2. Wallets: Owner can do anything. Members can read and update (for balance/sharing).
+    match /wallets/{walletId} {
+      allow read, update: if request.auth != null && (
+        resource.data.userId == request.auth.uid || 
+        (resource.data.sharedWith != null && request.auth.uid in resource.data.sharedWith)
+      );
+      allow create: if request.auth != null && request.resource.data.userId == request.auth.uid;
+      allow delete: if request.auth != null && resource.data.userId == request.auth.uid;
+    }
+    
+    // 3. Transactions: Creator or Wallet Owner can manage. Wallet members can read/create.
+    match /transactions/{transactionId} {
+      allow read: if request.auth != null && (
+        resource.data.userId == request.auth.uid || 
+        isWalletOwner(resource.data.walletId) || 
+        isWalletMember(resource.data.walletId)
+      );
+      allow create: if request.auth != null && 
+        request.resource.data.userId == request.auth.uid && 
+        (isWalletOwner(request.resource.data.walletId) || isWalletMember(request.resource.data.walletId));
+        
+      allow update, delete: if request.auth != null && (
+        resource.data.userId == request.auth.uid || 
+        isWalletOwner(resource.data.walletId)
+      );
+    }
+  }
+}


### PR DESCRIPTION
Additional robustness fixes to prevent permission errors during high-frequency wallet creation or when sharedWith field is missing.